### PR TITLE
Hotfixing v0.3: Add count field in department serializer

### DIFF
--- a/apps/lecture/serializers.py
+++ b/apps/lecture/serializers.py
@@ -63,7 +63,7 @@ class LectureSerializer(serializers.ModelSerializer):
 
 
 class DepartmentSerializer(serializers.ModelSerializer):
-    count = serializers.IntegerField(source='get_number_of_lecture_in_department', read_only=True)
+    count = serializers.IntegerField(source='get_number_of_lectures_in_department', read_only=True)
 
     class Meta:
         model = Department


### PR DESCRIPTION
A little typo in department serializer caused API to not return `count` value. This pull request addressed this issue.